### PR TITLE
Graceful exit on uninstall

### DIFF
--- a/modules/system/themes/redmexico/redmexico.php
+++ b/modules/system/themes/redmexico/redmexico.php
@@ -15,30 +15,6 @@ global $xoopsConfig, $rmc_config;
 //require_once XOOPS_ROOT_PATH.'/modules/rmcommon/admin_loader.php';
 
 if ($xoopsModule && ($xoopsModule->getInfo('rmnative') || !$rmc_config['gui_disable'])) {
-    /**
-     * XOOPS 2.5.8 changes the definition of XoopsSystemGui::validate() to static, as it is used in
-     * call_user_func(). While that fixes warnings, changing the declaration breaks backward compatibility
-     * and creates errors. This shim declares the method appropriate to the definition in XoopsSystemGui.
-     * 2.5.8 works without warnings, and 2.5.7 and earlier work without error.
-     */
-    $reflectionGui = new ReflectionClass('XoopsSystemGui');
-    if ($reflectionGui->getMethod('validate')->isStatic()) {
-        class XoopsGuiRedmexicoShim extends XoopsSystemGui
-        {
-            public static function validate()
-            {
-                return true;
-            }
-        }
-    } else {
-        class XoopsGuiRedmexicoShim extends XoopsSystemGui
-        {
-            public function validate()
-            {
-                return true;
-            }
-        }
-    }
 
     /**
      * XOOPS CPanel "redmexico" GUI class
@@ -48,13 +24,23 @@ if ($xoopsModule && ($xoopsModule->getInfo('rmnative') || !$rmc_config['gui_disa
      * @author      BitC3R0       <i.bitcero@gmail.com>
      * @version     1.0
      */
-    class XoopsGuiRedmexico extends XoopsGuiRedmexicoShim
+    class XoopsGuiRedmexico extends XoopsSystemGui
     {
         public function __construct()
         {
         }
 
-        //public static function validate(){ return true; }
+        /**
+         * Check to see if theme is currently valid.
+         *
+         * For redmexico theme, this means that rmcommon is available
+         *
+         * @return bool true if theme can be used, otherwise false
+         */
+        public static function validate()
+        {
+            return class_exists('RMTemplate');
+        }
 
         public function header()
         {

--- a/rmcommon/modules.php
+++ b/rmcommon/modules.php
@@ -1278,7 +1278,7 @@ function module_disable_now($enable = 0)
     }
 
     RMEvents::get()->run_event('rmcommon.module.disabled', $module);
-
+    xoops_setActiveModules();
     redirectMsg('modules.php', sprintf(__('Module %s successfully disabled!', 'rmcommon'), $module->name()), 0);
 }
 

--- a/rmcommon/redmexico/redmexico.php
+++ b/rmcommon/redmexico/redmexico.php
@@ -15,30 +15,6 @@ global $xoopsConfig, $rmc_config;
 //require_once XOOPS_ROOT_PATH.'/modules/rmcommon/admin_loader.php';
 
 if ($xoopsModule && ($xoopsModule->getInfo('rmnative') || !$rmc_config['gui_disable'])) {
-    /**
-     * XOOPS 2.5.8 changes the definition of XoopsSystemGui::validate() to static, as it is used in
-     * call_user_func(). While that fixes warnings, changing the declaration breaks backward compatibility
-     * and creates errors. This shim declares the method appropriate to the definition in XoopsSystemGui.
-     * 2.5.8 works without warnings, and 2.5.7 and earlier work without error.
-     */
-    $reflectionGui = new ReflectionClass('XoopsSystemGui');
-    if ($reflectionGui->getMethod('validate')->isStatic()) {
-        class XoopsGuiRedmexicoShim extends XoopsSystemGui
-        {
-            public static function validate()
-            {
-                return true;
-            }
-        }
-    } else {
-        class XoopsGuiRedmexicoShim extends XoopsSystemGui
-        {
-            public function validate()
-            {
-                return true;
-            }
-        }
-    }
 
     /**
      * XOOPS CPanel "redmexico" GUI class
@@ -48,15 +24,22 @@ if ($xoopsModule && ($xoopsModule->getInfo('rmnative') || !$rmc_config['gui_disa
      * @author      BitC3R0       <i.bitcero@gmail.com>
      * @version     1.0
      */
-    class XoopsGuiRedmexico extends XoopsGuiRedmexicoShim
+    class XoopsGuiRedmexico extends XoopsSystemGui
     {
         public function __construct()
         {
         }
 
+        /**
+         * Check to see if theme is currently valid.
+         *
+         * For redmexico theme, this means that rmcommon is available
+         *
+         * @return bool true if theme can be used, otherwise false
+         */
         public static function validate()
         {
-            return true;
+            return class_exists('RMTemplate');
         }
 
         public function header()
@@ -90,7 +73,7 @@ if ($xoopsModule && ($xoopsModule->getInfo('rmnative') || !$rmc_config['gui_disa
             //if (!isset($xoTheme)) $xoTheme =& $GLOBALS['xoTheme'];
 
             if (!isset($xoTheme)) {
-                $xoTheme = &$GLOBALS['xoTheme'];
+                $xoTheme = $GLOBALS['xoTheme'];
             }
 
             if (isset($xoopsOption['template_main']) && $xoopsOption['template_main'] != $xoTheme->contentTemplate) {


### PR DESCRIPTION
- add check for rmcommon in XoopsGuiRedmexico::validate()
- remove shim for pre-XOOPS 2.5.8 systems
- rebuild active module cache after deactivating a module